### PR TITLE
Fix action

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -1,14 +1,16 @@
 name: Release New Action Version
-on: 
+
+on:
   push:
     branches:
       - "main"
+
 jobs:
   release-action:
     name: Release new version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,18 +1,18 @@
 name: Test resharper-action
-on: 
+
+on:
   push:
     branches:
       - "*"
       - "!main"
   workflow_dispatch:
-  
+
 jobs:
   test-action:
     name: Test resharper-action
-    runs-on: ubuntu-20.04
-
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Create Solution
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+NuGet.Config
+
+# VS Code
+.vscode
+
+# VS

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # resharper-action
+
 A GitHub Action for running ReSharper. We recommend using patriotsoftware/resharper-action@v1 to get the latest changes. If new features require breaking changes, we will release them to @v2. You can also use a full semantic version tag.
 
-# Example Usage
-```- uses: patriotsoftware/resharper-action@v1```
-# Inputs
+## Example Usage
+
+```yaml
+- uses: patriotsoftware/resharper-action@v1
 ```
+
+## Inputs
+
+```yaml
 solution-name:
   This is the name of the solution file.
 exclude-list:
@@ -15,4 +21,3 @@ severity-level:
 file-type:
   Default is xml. Options (xml or json)
 ```
-

--- a/action-json.ps1
+++ b/action-json.ps1
@@ -1,13 +1,18 @@
-dotnet tool install -g Jetbrains.Resharper.GlobalTools
+dotnet tool install --global Jetbrains.Resharper.GlobalTools --version "$env:INPUTS_TOOL_VERSION"
 
-#Add check for correct solution name
-New-Item -Path 'inspections.json' -ItemType File
+$inspectionsFile = "inspections.json"
 Write-Host $env:INPUTS_SEVERITY_LEVEL
-jb inspectcode $env:INPUTS_SOLUTION_NAME --exclude=$env:INPUTS_EXCLUDE_LIST -s="$env:INPUTS_SEVERITY_LEVEL" -o="inspections.json"
-ls
+
+jb inspectcode $env:INPUTS_SOLUTION_NAME --exclude="$env:INPUTS_EXCLUDE_LIST" --sEverity="$env:INPUTS_SEVERITY_LEVEL" --format="json" --output="$inspectionsFile"
+
+if ($LASTEXITCODE -ne 0) {
+  Write-Host "Error: jb inspectcode command failed with exit code $LASTEXITCODE"
+  exit $LASTEXITCODE
+}
+
+ls "$inspectionsFile"
 
 $inspections = (Get-Content -Path inspections.json -Raw | ConvertFrom-Json)
-
 $errors = $inspections.runs.results | ? { $_.level -eq "error" }
 
 if ($errors.Length -ne 0 )
@@ -16,3 +21,6 @@ if ($errors.Length -ne 0 )
     $errors | % { echo "ERROR - $($_.ruleId) - $($_.locations[0].physicalLocation.artifactLocation.uri) line $($_.locations[0].physicalLocation.region.startLine) - $($_.message.text)" }
     exit 1
 }
+
+Write-Host "SUCCESS - No errors identified in solution."
+exit 0

--- a/action-xml.ps1
+++ b/action-xml.ps1
@@ -1,17 +1,26 @@
-dotnet tool install -g Jetbrains.Resharper.GlobalTools
+dotnet tool install --global Jetbrains.Resharper.GlobalTools --version "$env:INPUTS_TOOL_VERSION"
 
-#Add check for correct solution name
-New-Item -Path 'inspections.xml' -ItemType File
+$inspectionsFile = "inspections.xml"
 Write-Host $env:INPUTS_SEVERITY_LEVEL
-jb inspectcode $env:INPUTS_SOLUTION_NAME --exclude=$env:INPUTS_EXCLUDE_LIST -s="$env:INPUTS_SEVERITY_LEVEL" -o="inspections.xml"
-ls
 
-[xml]$inspections = [xml](Get-Content -Path inspections.xml)
+jb inspectcode $env:INPUTS_SOLUTION_NAME --exclude="$env:INPUTS_EXCLUDE_LIST" --severity="$env:INPUTS_SEVERITY_LEVEL" --format="xml" --output="$inspectionsFile"
+
+if ($LASTEXITCODE -ne 0) {
+  Write-Host "Error: jb inspectcode command failed with exit code $LASTEXITCODE"
+  exit $LASTEXITCODE
+}
+
+ls "$inspectionsFile"
+
+[xml]$inspections = [xml](Get-Content -Path "$inspectionsFile")
 $errorIssueTypes = $inspections.Report.IssueTypes.IssueType | ? { $_.Severity -eq $env:INPUTS_SEVERITY_LEVEL } | % { $_.Id }
 $errors = $inspections.Report.Issues.Project.Issue | ? { $errorIssueTypes -Contains $_.TypeId }
 if ($errors.Count -ne 0 )
 {
-    echo "FAIL - Identified $($errors.Count) errors in solution."
-    $errors | % { echo "ERROR - $($_.ParentNode.Name) - $($_.TypeId) - $($_.File) line $($_.Line) - $($_.Message)" }
-    exit 1
+  echo "FAIL - Identified $($errors.Count) errors in solution."
+  $errors | % { echo "ERROR - $($_.ParentNode.Name) - $($_.TypeId) - $($_.File) line $($_.Line) - $($_.Message)" }
+  exit 1
 }
+
+Write-Host "SUCCESS - No errors identified in solution."
+exit 0

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ author: DevOps
 description: Run ReSharper
 
 inputs:
-  solution-name: 
+  solution-name:
     description: The name of your solution file
     required: true
   exclude-list:
@@ -16,14 +16,20 @@ inputs:
     description: xml or json
     default: 'xml'
     required: false
+  tool-version:
+    description: The version of the tool to use
+    default: '2024.3.6'
+    required: false
 
 runs:
   using: "composite"
   steps:
     - id: resharper-action
       env:
-        INPUTS_SOLUTION_NAME: ${{ inputs.solution-name }}
-        INPUTS_EXCLUDE_LIST: ${{ inputs.exclude-list }}
-        INPUTS_SEVERITY_LEVEL: ${{ inputs.severity-level }}
+        INPUTS_SOLUTION_NAME: '${{ inputs.solution-name }}'
+        INPUTS_EXCLUDE_LIST: '${{ inputs.exclude-list }}'
+        INPUTS_SEVERITY_LEVEL: '${{ inputs.severity-level }}'
+        INPUTS_FILE_TYPE: '${{ inputs.file-type }}'
+        INPUTS_TOOL_VERSION: '${{ inputs.tool-version }}'
       run: ${{ github.action_path }}/action-${{ inputs.file-type }}.ps1
       shell: pwsh


### PR DESCRIPTION
The resharper action is broken [logs](https://github.com/SynergyDataSystems/PatriotSoftware.TrueTax/actions/runs/14133252355/job/39598686688?pr=289#step:5:33)

Current action produces the following output:

```bash
ERROR
JetBrains Inspect Code 2024.3.6
Running on x64 OS in x64 architecture, .NET 9.0.3 under Ubuntu 24.04.2 LTS
Warning: Starting from version 2024.1, the default output format of InspectCode is SARIF.
The XML format will soon be deprecated. Results in the XML format are still available in the current version using the -f="xml" parameter.
Unable to find custom settings profile in path /runner/_work/PatriotSoftware.TrueTax/PatriotSoftware.TrueTax/ERROR
...
```

For reference, the command we're running is:

```bash
jb inspectcode $env:INPUTS_SOLUTION_NAME --exclude=$env:INPUTS_EXCLUDE_LIST -s="$env:INPUTS_SEVERITY_LEVEL" -o="inspections.xml"
```

> Starting from version 2024.1, the default output format of InspectCode is Static Analysis Results Interchange Format (SARIF). The XML format, which was the default in previous versions, will soon be deprecated. Results in the XML format are still available with the -f="xml" parameter.

We can retain expected behavior by setting both the output and format parameters.

```bash
--output=inspections.xml --format=xml
```

```bash
-s="$env:INPUTS_SEVERITY_LEVEL"
```

is the wrong flag. `-s` is

```bash
--settings (-s) : Path to the file to use custom settings from (default: Use R#'s solution shared settings if exists).
```

This is producing the error:

```bash
Unable to find custom settings profile in path /runner/_work/PatriotSoftware.TrueTax/PatriotSoftware.TrueTax/ERROR
```

The correct flag is

```bash
--sEverity (-e) : Minimal severity level to report [INFO, HINT, SUGGESTION, WARNING, ERROR] (default: SUGGESTION).
```

```bash
--exclude=$env:INPUTS_EXCLUDE_LIST
```

results in something like:

```bash
--exclude=**\appsettings.Local.json;**\NuGet.Config
```

The exclude list is expanded which is not the behavior we want. We want the glob patterns to be honored.

We can fix this by quoting the exclude list.

```bash
--exclude="$env:INPUTS_EXCLUDE_LIST"
```

The command is failing, but the action is not reporting the failure.

The action writes an empty file before running `jb inspectcode`

```bash
New-Item -Path inspections.xml -ItemType File
```

The script only checks for errors in the xml file. The command fails, the xml file is empty, it is parsed for error level failures, 0 are found, and the script reports success/no errors.

```bash
jb inspectcode $env:INPUTS_SOLUTION_NAME --exclude="$env:INPUTS_EXCLUDE_LIST" --severity="$env:INPUTS_SEVERITY_LEVEL" --format="xml" --output="$inspectionsFile"
```

And check the exit code for jb. Powershell has a built in magic variable.

```bash
if ($LASTEXITCODE -ne 0) {
  Write-Host "Error: jb inspectcode command failed with exit code $LASTEXITCODE"
  exit $LASTEXITCODE
}
```

The action creates an empty file before running the command. This is not the behavior we want.

```bash
New-Item -Path inspections.xml -ItemType File
```

So breaking changes don't sneak up on us, use a consistent tool version. This is passed in as an input to the action but it has a default set.